### PR TITLE
"login" mutation and "site credentials" option implemented

### DIFF
--- a/includes/admin/settings/class-main.php
+++ b/includes/admin/settings/class-main.php
@@ -24,12 +24,17 @@ class Main extends Section {
 	 */
 	public function __construct() {
 		$this->settings = array(
+			'wpgraphql_acao_credentials'      => array(
+				'type'        => 'Boolean',
+				'description' => __( 'If checked, site credentials including cookies will be passed in WPGraphQL requests', 'wp-graphql-cors' ),
+				'label'       => __( 'Send site credentials.', 'wp-graphql-cors' ),
+				'default'     => false,
+			),
 			'wpgraphql_acao_use_site_address' => array(
-				'type'              => 'Boolean',
-				'description'       => __( 'If checked, the current Site URL as set in <pre>Settings > General</pre> will be added to the Access-Control-Allow-Origin header. Extra domains can be added below.', 'wp-graphql-cors' ),
-				'label'             => __( 'Add Site Address to "Access-Control-Allow-Origin" header', 'wp-graphql-cors' ),
-				'default'           => true,
-				'sanitize_callback' => 'sanitize_text_field',
+				'type'        => 'Boolean',
+				'description' => __( 'If checked, the current Site URL as set in <pre>Settings > General</pre> will be added to the Access-Control-Allow-Origin header. Extra domains can be added below.', 'wp-graphql-cors' ),
+				'label'       => __( 'Add Site Address to "Access-Control-Allow-Origin" header', 'wp-graphql-cors' ),
+				'default'     => true,
 			),
 			'wpgraphql_acao'                  => array(
 				'type'              => 'String',
@@ -40,14 +45,20 @@ class Main extends Section {
 			),
 			'wpgraphql_cookie_filter'         => array(
 				'type'              => 'String',
-				'description'       => __( 'By default this plugin sends all cookies along in a response. You can specify specific cookie names here if you want to limit this.', 'wp-graphql-cors' ),
+				'description'       => __( 'By default this plugin sends all cookies along in a response. You can specify specific cookie names here if you want to limit this. "Send site credentials" must be enabled.', 'wp-graphql-cors' ),
 				'label'             => __( 'Filter WP GraphQL response cookies', 'wp-graphql-cors' ),
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
 			),
+			'wpgraphql_login_mutation'        => array(
+				'type'        => 'Boolean',
+				'description' => __( 'This extends WP GraphQL to have a login mutation. "Send site credentials" must be enabled.', 'wp-graphql-cors' ),
+				'label'       => __( 'Enable login mutation', 'wp-graphql-cors' ),
+				'default'     => false,
+			),
 			'wpgraphql_logout_mutation'       => array(
 				'type'        => 'Boolean',
-				'description' => __( 'This extends WP GraphQL to have a logout mutation. This is useful if you want add logout button on your frontend.', 'wp-graphql-cors' ),
+				'description' => __( 'This extends WP GraphQL to have a logout mutation. This is useful if you want add logout button on your frontend. "Send site credentials" must be enabled.', 'wp-graphql-cors' ),
 				'label'       => __( 'Enable logout mutation', 'wp-graphql-cors' ),
 				'default'     => false,
 			),

--- a/includes/class-wp-graphql-cors.php
+++ b/includes/class-wp-graphql-cors.php
@@ -58,6 +58,7 @@ class WP_GraphQL_CORS {
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/admin/settings/class-section.php';
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/admin/settings/class-main.php';
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/process-request.php';
+		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/login-mutation.php';
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/logout-mutation.php';
 	}
 
@@ -68,6 +69,7 @@ class WP_GraphQL_CORS {
 		add_action( 'admin_init', 'wpgraphql_cors_admin_page_init' );
 		add_action( 'admin_menu', 'wpgraphql_cors_admin_menu' );
 		add_action( 'graphql_process_http_request_response', 'wpgraphql_cors_filter_cookies', 10 );
+		add_action( 'graphql_register_types', 'wpgraphql_cors_login_mutation' );
 		add_action( 'graphql_register_types', 'wpgraphql_cors_logout_mutation' );
 	}
 

--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Define functions for registering the 'logout' mutation to GraphQL Schema.
+ *
+ * @since 0.0.1
+ * @package wp-graphql-cors
+ */
+
+use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
+/**
+ * Register logout mutation for killing a user's session and all corresponding cookies.
+ */
+function wpgraphql_cors_login_mutation() {
+	if ( 'on' === get_option( 'wpgraphql_login_mutation', 'off' ) ) {
+		/**
+		 * Registers the logout mutation.
+		 */
+		register_graphql_mutation(
+			'login',
+			array(
+				'inputFields'         => array(
+					'login'      => array(
+						'type'        => array( 'non_null' => 'String' ),
+						'description' => __( 'Input your user/e-mail.', 'wp-graphql-cors' ),
+					),
+					'password'   => array(
+						'type'        => array( 'non_null' => 'String' ),
+						'description' => __( 'Input your password.', 'wp-graphql-cors' ),
+					),
+					'rememberMe' => array(
+						'type'        => 'Boolean',
+						'description' => __(
+							'Whether to "remember" the user. Increases the time that the cookie will be kept. Default false.',
+							'wp-graphql-cors'
+						),
+					),
+				),
+				'outputFields'        => array(
+					'status' => array(
+						'type'        => 'String',
+						'description' => 'Login operation status',
+						'resolve'     => function( $payload ) {
+							return $payload['status'];
+						},
+					),
+				),
+				'mutateAndGetPayload' => function() {
+					// Prepare credentials.
+					$credential_keys = array(
+						'login'      => 'user_login',
+						'password'   => 'user_password',
+						'rememberMe' => 'remember',
+					);
+					$credentials     = array();
+					foreach ( $input as $key => $value ) {
+						if ( in_array( $key, array_keys( $credential_keys ), true ) ) {
+							$credentials[ $credential_keys[ $key ] ] = $value;
+						}
+					}
+
+					// Authenticate User.
+					$user = wp_signon( $credentials, true );
+
+					if ( is_wp_error( $user ) ) {
+						throw new UserError( $user->get_message() );
+					}
+
+					return array( 'status' => 'SUCCESS' );
+				},
+			)
+		);
+	}
+}

--- a/includes/process-request.php
+++ b/includes/process-request.php
@@ -53,7 +53,9 @@ function wpgraphql_cors_response_headers( $headers ) {
 		$headers['Access-Control-Allow-Origin'] = get_http_origin();
 	}
 
-	if ( ! empty( $headers['Access-Control-Allow-Origin'] ) && '*' !== $headers['Access-Control-Allow-Origin'] ) {
+	if ( ! empty( $headers['Access-Control-Allow-Origin'] )
+		&& '*' !== $headers['Access-Control-Allow-Origin']
+		&& get_option( 'wpgraphql_acao_credentials', false ) ) {
 		$headers['Access-Control-Allow-Credentials'] = 'true';
 	}
 	return $headers;


### PR DESCRIPTION
#### Implements
- "login" mutation added.
```
mutation ($input: LoginInput!) {
  login(input: $input) {
    status
    user {
      id
    }
  }
}
```
  - LoginInput Definition
  ```
'login'      => array(
	'type'        => array( 'non_null' => 'String' ),
	'description' => __( 'Input your user/e-mail.', 'wp-graphql-cors' ),
),
'password'   => array(
	'type'        => array( 'non_null' => 'String' ),
	'description' => __( 'Input your password.', 'wp-graphql-cors' ),
),
'rememberMe' => array(
	'type'        => 'Boolean',
	'description' => __(
		'Whether to "remember" the user. Increases the time that the cookie will be kept. Default false.',
		'wp-graphql-cors'
	),
),
  ```
- "Send site credential" option added. If checked, site credential including cookies will be sent when responding to GraphQL requests from allow domains.

#### Closes 
#4 