### PR TITLE
"login" to "loginWithCookies" to fix collisions

### DIFF
--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -19,7 +19,7 @@ function wpgraphql_cors_login_mutation() {
 		 * Registers the logout mutation.
 		 */
 		register_graphql_mutation(
-			'login',
+			'loginWithCookies',
 			array(
 				'inputFields'         => array(
 					'login'      => array(


### PR DESCRIPTION
To prevent collisions with the **[WPGraphQL-JWT-Authentication](https://github.com/wp-graphql/wp-graphql-jwt-authentication)**'s `login` mutation, the `login` mutation has been renamed `loginWithCookies`.

Closes #8 