### PR TITLE
🐛 Add missing undefinded variable input

### DIFF
--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -47,7 +47,7 @@ function wpgraphql_cors_login_mutation() {
 						},
 					),
 				),
-				'mutateAndGetPayload' => function() {
+				'mutateAndGetPayload' => function( $input ) {
 					// Prepare credentials.
 					$credential_keys = array(
 						'login'      => 'user_login',


### PR DESCRIPTION
When running the `loginWithCookies` mutation, the server errors out and doesn't return an expected value. Looking at my Sentry report, it looks as though there's a missing variable.

Specifically, the `mutateAndGetPayload` is missing the `$input` variable in its callback function. As a result, the subsequent `foreach` is throwing an ErrorException for an invalid argument.

Sentry report: https://sentry.io/share/issue/bb2aaa28f07a4c48bc917ee51a9f05b8/