### PR TITLE
[Docs]: Update login mutation example name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If enabled in the settings, WP GraphQL will have a new mutation available to all
 
 ```
 mutation {
-	login(input: {clientMutationId: "", login: "", password: ""}) {
+	loginWithCookies(input: {clientMutationId: "", login: "", password: ""}) {
         clientMutationId
         status
     }


### PR DESCRIPTION
The current example name is incorrect and reflects an older mutation.