### PR TITLE
Use correct error method on sign in failures

### DIFF
--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -65,7 +65,7 @@ function wpgraphql_cors_login_mutation() {
 					$user = wp_signon( $credentials, true );
 
 					if ( is_wp_error( $user ) ) {
-						throw new UserError( $user->get_message() );
+						throw new UserError( ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login' ) );
 					}
 
 					return array( 'status' => 'SUCCESS' );

--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -65,7 +65,7 @@ function wpgraphql_cors_login_mutation() {
 					$user = wp_signon( $credentials, true );
 
 					if ( is_wp_error( $user ) ) {
-						throw new UserError( ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login' ) );
+						throw new UserError( ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login' );
 					}
 
 					return array( 'status' => 'SUCCESS' );


### PR DESCRIPTION
On a sign in failure, the `wp_signon()` function returns an instance of `WP_Error`. Unfortunately, `get_message()` isn't a valid method for that class, so API consumers get an 'invalid method get_message()' error instead of the actual message.