### PR TITLE
Adding Access Control Allow Header custom field & logic to implement …

### DIFF
--- a/includes/admin/settings/class-access.php
+++ b/includes/admin/settings/class-access.php
@@ -34,14 +34,21 @@ class Access extends Section {
 				'label'       => __( 'Add Site Address to "Access-Control-Allow-Origin" header', 'wp-graphql-cors' ),
 				'default'     => true,
 			),
-			'wpgraphql_acao'                  => array(
+				'wpgraphql_acao'                  => array(
 				'type'              => 'Text',
 				'description'       => __( 'Authorized domains requests can originate from. One domain per line. Be sure to include the protocol, like so: http://example.com', 'wp-graphql-cors' ),
 				'label'             => __( 'Extend "Access-Control-Allow-Origin” header', 'wp-graphql-cors' ),
 				'default'           => '*',
 				'sanitize_callback' => 'sanitize_textarea_field',
-            ),
-            'wpgraphql_acao_block_unauthorized' => array(
+			),
+				'wpgraphql_acah' => array(
+				'type'              => 'Text',
+				'description'       => __( 'Custom headers fields. One field per line. Like so: X-Custom-Field', 'wp-graphql-cors' ),
+				'label'             => __( 'Extend "Access-Control-Allow-Headers”', 'wp-graphql-cors' ),
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+				'wpgraphql_acao_block_unauthorized' => array(
 				'type'        => 'Boolean',
 				'description' => __( 'If checked, all GraphQL requests made from unauthorized domains will be blocked', 'wp-graphql-cors' ),
 				'label'       => __( 'Block unauthorized domains', 'wp-graphql-cors' ),

--- a/includes/process-request.php
+++ b/includes/process-request.php
@@ -46,6 +46,25 @@ function wpgraphql_cors_response_headers( $headers ) {
 		$headers['Access-Control-Allow-Credentials'] = 'true';
 	}
 
+	// If custom headers exist apply them
+	$custom_headers = array();
+	$acah = get_option( 'wpgraphql_acah' );
+	if ( $acah !== '' ) {
+		$acah = explode( PHP_EOL, $acah );
+		$custom_headers = array_merge( $custom_headers, array_map( 'trim', $acah ) );
+
+		// Remove any empty origins.
+		$custom_headers = array_filter( $custom_headers );
+	}
+	$access_control_allow_headers = apply_filters(
+		'graphql_access_control_allow_headers',
+		[
+			'Authorization',
+			'Content-Type',
+		]
+	);
+	$headers['Access-Control-Allow-Headers'] = implode( ', ', array_merge($access_control_allow_headers, $custom_headers) );
+
 	return $headers;
 }
 


### PR DESCRIPTION
This will allow a user to add it's own custom fields
into headers and that way prevent any cors issues with custom fields
being sent along the request

![image](https://user-images.githubusercontent.com/10183602/91470210-b7856d00-e894-11ea-8d47-dca7fbf212ab.png)


EDIT:
Reason behind this PR was that we have an apollo client that sends a custom parameter in headers when it reaches out to multiple services. In order to reduce amount of complexity on the client side we've thought it might benefit others to be able to add custom fields to headers within their projects.

Please do point out if any of the updates don't make sense or require some more info etc. 