### PR TITLE
Adds replacements for wp_signon, wp_set_auth_cookie and setcookie.

### DIFF
--- a/includes/class-wp-graphql-cors.php
+++ b/includes/class-wp-graphql-cors.php
@@ -62,6 +62,9 @@ class WP_GraphQL_CORS {
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/process-request.php';
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/login-mutation.php';
 		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/logout-mutation.php';
+		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/signon.php';
+		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/set-auth-cookie.php';
+		require_once WPGRAPHQL_CORS_PLUGIN_DIR . '/includes/setcookie-same-site.php';
 	}
 
 	/**

--- a/includes/login-mutation.php
+++ b/includes/login-mutation.php
@@ -62,7 +62,7 @@ function wpgraphql_cors_login_mutation() {
 					}
 
 					// Authenticate User.
-					$user = wp_signon( $credentials, true );
+					$user = wpgraphql_cors_signon( $credentials, true );
 
 					if ( is_wp_error( $user ) ) {
 						throw new UserError( ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login' );

--- a/includes/set-auth-cookie.php
+++ b/includes/set-auth-cookie.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Alternate wp_set_auth_cookie function
+ *
+ * @since 1.1.1
+ * @package wp-graphql-cors
+ */
+
+/**
+ * Sets the authentication cookies based on user ID.
+ * Provides an alternative to wp_set_auth_cookie that supports the samesite cookie attribute.
+ *
+ * @see wp_set_auth_cookie
+ *
+ * @param int         $user_id  User ID.
+ * @param bool        $remember Whether to remember the user.
+ * @param bool|string $secure   Whether the auth cookie should only be sent over HTTPS. Default is an empty
+ *                              string which means the value of `is_ssl()` will be used.
+ * @param string      $token    Optional. User's session token to use for this cookie.
+ */
+function wpgraphql_cors_set_auth_cookie( $user_id, $remember = false, $secure = '', $token = '' ) {
+	if ( $remember ) {
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user_id, $remember );
+
+			$expire = $expiration + ( 12 * HOUR_IN_SECONDS );
+	} else {
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user_id, $remember );
+			$expire     = 0;
+	}
+
+	if ( '' === $secure ) {
+			$secure = is_ssl();
+	}
+
+	$secure_logged_in_cookie = $secure && 'https' === wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME );
+
+	$secure = apply_filters( 'secure_auth_cookie', $secure, $user_id );
+
+	$secure_logged_in_cookie = apply_filters( 'secure_logged_in_cookie', $secure_logged_in_cookie, $user_id, $secure );
+
+	if ( $secure ) {
+			$auth_cookie_name = SECURE_AUTH_COOKIE;
+			$scheme           = 'secure_auth';
+	} else {
+			$auth_cookie_name = AUTH_COOKIE;
+			$scheme           = 'auth';
+	}
+
+	if ( '' === $token ) {
+			$manager = WP_Session_Tokens::get_instance( $user_id );
+			$token   = $manager->create( $expiration );
+	}
+
+	$auth_cookie      = wp_generate_auth_cookie( $user_id, $expiration, $scheme, $token );
+	$logged_in_cookie = wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token );
+
+	do_action( 'set_auth_cookie', $auth_cookie, $expire, $expiration, $user_id, $scheme, $token );
+
+	do_action( 'set_logged_in_cookie', $logged_in_cookie, $expire, $expiration, $user_id, 'logged_in', $token );
+
+	if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+	}
+
+	wpgraphql_cors_setcookie_same_site( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
+	wpgraphql_cors_setcookie_same_site( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
+	wpgraphql_cors_setcookie_same_site( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+	if ( COOKIEPATH !== SITECOOKIEPATH ) {
+			wpgraphql_cors_setcookie_same_site( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+	}
+}

--- a/includes/setcookie-same-site.php
+++ b/includes/setcookie-same-site.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Alternate setcookie function
+ * Wrapper for the native php function setcookie.
+ *
+ * @since 1.1.1
+ * @package wp-graphql-cors
+ */
+
+/**
+ * Wrapper for setcookie that will add samesite to the cookie.
+ *
+ * @param string $name The name of the cookie.
+ * @param string $value The value of the cookie.
+ * @param int    $expires The time the cookie expires.
+ * @param string $path The path on the server in which the cookie will be available on.
+ * @param string $domain The (sub)domain that the cookie is available to.
+ * @param bool   $secure Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client.
+ * @param bool   $httponly When TRUE the cookie will be made accessible only through the HTTP protocol.
+ * @param string $samesite None, Strict, or Lax. Defaults to None.
+ * @return void
+ */
+function wpgraphql_cors_setcookie_same_site( $name, $value, $expires, $path, $domain, $secure, $httponly, $samesite = 'None' ) {
+	if ( PHP_VERSION_ID < 70300 ) {
+			setcookie( $name, $value, $expires, "$path; samesite=$samesite", $domain, $secure, $httponly );
+	} else {
+		setcookie(
+			$name,
+			$value,
+			array(
+				'expires'  => $expires,
+				'path'     => $path,
+				'domain'   => $domain,
+				'samesite' => $samesite,
+				'secure'   => $secure,
+				'httponly' => $httponly,
+			)
+		);
+	}
+}

--- a/includes/signon.php
+++ b/includes/signon.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Alternate wp_signon function
+ *
+ * @since 1.1.1
+ * @package wp-graphql-cors
+ *
+ * phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+ */
+
+/**
+ * Authenticates and logs a user in with 'remember' capability.
+ * Replacement for wp_signon so that we can drop in a new wp_set_auth_cookie.
+ *
+ * @see wp_signon
+ *
+ * @global string $auth_secure_cookie
+ *
+ * @param array       $credentials   Optional. User info in order to sign on.
+ * @param string|bool $secure_cookie Optional. Whether to use secure cookie.
+ * @return WP_User|WP_Error WP_User on success, WP_Error on failure.
+ */
+function wpgraphql_cors_signon( $credentials = array(), $secure_cookie = '' ) {
+	if ( empty( $credentials ) ) {
+			$credentials = array();
+
+		if ( ! empty( $_POST['log'] ) ) {
+				$credentials['user_login'] = wp_unslash( $_POST['log'] );
+		}
+		if ( ! empty( $_POST['pwd'] ) ) {
+				$credentials['user_password'] = $_POST['pwd'];
+		}
+		if ( ! empty( $_POST['rememberme'] ) ) {
+				$credentials['remember'] = $_POST['rememberme'];
+		}
+	}
+
+	if ( ! empty( $credentials['remember'] ) ) {
+			$credentials['remember'] = true;
+	} else {
+			$credentials['remember'] = false;
+	}
+
+	do_action_ref_array( 'wp_authenticate', array( &$credentials['user_login'], &$credentials['user_password'] ) );
+
+	if ( '' === $secure_cookie ) {
+			$secure_cookie = is_ssl();
+	}
+
+	$secure_cookie = apply_filters( 'secure_signon_cookie', $secure_cookie, $credentials );
+	global $auth_secure_cookie;
+	$auth_secure_cookie = $secure_cookie; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+	add_filter( 'authenticate', 'wp_authenticate_cookie', 30, 3 );
+
+	$user = wp_authenticate( $credentials['user_login'], $credentials['user_password'] );
+
+	if ( is_wp_error( $user ) ) {
+			return $user;
+	}
+
+	wpgraphql_cors_set_auth_cookie( $user->ID, $credentials['remember'], $secure_cookie );
+
+	do_action( 'wp_login', $user->user_login, $user );
+	return $user;
+}

--- a/wp-graphql-cors.php
+++ b/wp-graphql-cors.php
@@ -5,7 +5,7 @@
  * and response cookie header.
  * Text Domain: wp-graphql-cors
  * Domain Path: /languages
- * Version: 1.1.0
+ * Version: 1.1.1
  *
  * @category WPGraphQL_Extension
  * @package  wp-graphql-cors


### PR DESCRIPTION
#19 

Adds the following functions: wpgraphql_cors_signon, wpgraphql_cors_set_auth_cookie, wpgraphql_cors_setcookie_same_site. WordPress does not have their cookies wrapped in an action so the entire functions need to be replicated. Luckily most functionality is in do_actions so most logic doesn't require duplication. The meat'n potatoes is in set-auth-cookie.php at ln65. It could probably be improved upon e.g. providing a settings bit.

Adding a filter and passing it as a last argument to wpgraphql_cors_setcookie_same_site would allow a Same Site option to be able to be passed in via configuration. However, I thought we could get this merged and then have that be a separate PR/Issue.