### PR TITLE
"shutdown" action now called on GraphQL requests

### DIFF
--- a/includes/class-wp-graphql-cors.php
+++ b/includes/class-wp-graphql-cors.php
@@ -75,6 +75,7 @@ class WP_GraphQL_CORS {
         add_action( 'do_graphql_request', 'wpgraphql_cors_api_authentication', 10 );
         add_action( 'graphql_register_types', 'wpgraphql_cors_login_mutation' );
         add_action( 'graphql_register_types', 'wpgraphql_cors_logout_mutation' );
+        add_action( 'graphql_return_response', 'wpgraphql_cors_shutdown' );
     }
 
     /**

--- a/includes/process-request.php
+++ b/includes/process-request.php
@@ -155,3 +155,7 @@ function wpgraphql_cors_api_authentication( $query ) {
 
     return $query;
 }
+
+function wpgraphql_cors_shutdown() {
+	do_action( 'shutdown' );
+}


### PR DESCRIPTION
Captures `cookies` typically written at the end of the WordPress request by executing the `shutdown` hook before the GraphQL response is returned.